### PR TITLE
fix: correct incomplete string in passwds_splitted comment check

### DIFF
--- a/kvmd/apps/kvmd/api/redfish.py
+++ b/kvmd/apps/kvmd/api/redfish.py
@@ -104,7 +104,7 @@ class RedfishApi:
                     "ResetType@Redfish.AllowableValues": list(self.__actions),
                     "target": "/redfish/v1/Systems/0/Actions/ComputerSystem.Reset",
                 },
-                "
+                "#ComputerSystem.SetDefaultBootOrder": {
                     "target": "/redfish/v1/Systems/0/Actions/ComputerSystem.SetDefaultBootOrder",
                 },
             },

--- a/kvmd/tools.py
+++ b/kvmd/tools.py
@@ -90,6 +90,6 @@ def passwds_splitted(text: str) -> Generator[tuple[int, str], None, None]:
     for (lineno, line) in enumerate(text.split("\n")):
         line = line.rstrip("\r")
         ls = line.strip()
-        if len(ls) == 0 or ls.startswith("
+        if len(ls) == 0 or ls.startswith("#"):
             continue
         yield (lineno, line)


### PR DESCRIPTION
- Fix incomplete string literal in startswith() call for comment detection